### PR TITLE
fix: hamburger menu responsiveness

### DIFF
--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -66,9 +66,11 @@ const Header = () => {
 
         {/* Nav Menu Start   */}
         <div
-          className={`w-full lg:w-full h-0 lg:h-auto invisible lg:visible lg:flex items-center justify-between ${navigationOpen &&
+          className={`w-full lg:w-full h-0 lg:h-auto invisible lg:visible lg:flex items-center justify-between lg:dark:bg-transparent lg:mt-0 lg:p-0 lg:shadow-none lg:overflow-auto
+          ${
+            navigationOpen &&
             '!visible bg-white dark:bg-blacksection shadow-solid-5 h-auto max-h-[400px] overflow-y-scroll rounded-md mt-4 p-7.5'
-            }`}
+          }`}
         >
           <nav>
             <ul className="flex lg:items-center flex-col lg:flex-row gap-5 lg:gap-10">


### PR DESCRIPTION
## Issue Description
When the browser window is minimized and the hamburger menu is activated, then the browser window is maximized again, the CSS properties associated with the hamburger menu persist, causing undesirable behavior. 

### Before:
[issue.webm](https://github.com/keyval-dev/landing-page/assets/82360525/1e912ab2-20e0-4d0f-9cfc-0b3a535e2279)

### After:
https://github.com/keyval-dev/landing-page/assets/82360525/829085be-e264-486e-93b3-558c9002cf01
