### PR TITLE
feat(events): optional HubSpot form embed on event pages

### DIFF
--- a/sanity/schemas/event.ts
+++ b/sanity/schemas/event.ts
@@ -66,6 +66,18 @@ export default defineType({
       rows: 10,
       description: 'Optional raw HTML to embed on the page (e.g. HubSpot CTA). Renders below the content.',
     }),
+    defineField({
+      name: 'hubspotFormId',
+      title: 'HubSpot Form ID',
+      type: 'string',
+      description: 'Optional. If set together with HubSpot Portal ID, the page renders an embedded HubSpot form instead of the default contact form.',
+    }),
+    defineField({
+      name: 'hubspotPortalId',
+      title: 'HubSpot Portal ID',
+      type: 'string',
+      description: 'Optional. Required alongside HubSpot Form ID to embed a HubSpot form.',
+    }),
   ],
   preview: {
     select: {

--- a/src/containers/event-single/event-hubspot-form/index.tsx
+++ b/src/containers/event-single/event-hubspot-form/index.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import React from 'react';
+import Script from 'next/script';
+import { useMobile } from '@/contexts';
+import styled from 'styled-components';
+import { Text } from '@/components';
+
+const Card = styled.div<{ $isMobile: boolean }>`
+  background: ${({ theme }) => theme.colors.grey_cold};
+  border-radius: 32px;
+  border: 1px solid ${({ theme }) => theme.colors.grey_darker};
+  padding: ${({ $isMobile }) => ($isMobile ? 32 : 64)}px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+
+  /* HubSpot form styling — dark theme, matches the rest of the events page */
+  .hs-form-html,
+  .hs-form {
+    width: 100%;
+  }
+
+  .hs-form fieldset {
+    max-width: 100% !important;
+    display: flex !important;
+    flex-direction: ${({ $isMobile }) => ($isMobile ? 'column' : 'row')} !important;
+    gap: 16px !important;
+  }
+
+  .hs-form fieldset .hs-form-field {
+    flex: 1 !important;
+    width: 100% !important;
+  }
+
+  .hs-form .hs-form-field {
+    margin-bottom: 16px;
+  }
+
+  .hs-form label {
+    display: block;
+    color: ${({ theme }) => theme.colors.white} !important;
+    font-size: 14px !important;
+    font-weight: 500 !important;
+    margin-bottom: 8px !important;
+    text-align: left !important;
+  }
+
+  .hs-form label .hs-form-required {
+    color: ${({ theme }) => theme.colors.pink} !important;
+  }
+
+  .hs-form .hs-input,
+  .hs-form input[type='text'],
+  .hs-form input[type='email'],
+  .hs-form input[type='tel'],
+  .hs-form input[type='number'],
+  .hs-form textarea,
+  .hs-form select {
+    width: 100% !important;
+    background: ${({ theme }) => theme.colors.black} !important;
+    border: 1px solid ${({ theme }) => theme.colors.grey_darker} !important;
+    border-radius: 8px !important;
+    padding: 14px 16px !important;
+    font-size: 14px !important;
+    color: ${({ theme }) => theme.colors.white} !important;
+    font-family: Inter, sans-serif !important;
+    box-sizing: border-box !important;
+    transition: border-color 0.2s ease !important;
+  }
+
+  .hs-form .hs-input:focus,
+  .hs-form input:focus,
+  .hs-form textarea:focus,
+  .hs-form select:focus {
+    outline: none !important;
+    border-color: ${({ theme }) => theme.colors.purple} !important;
+  }
+
+  .hs-form .hs-input::placeholder,
+  .hs-form input::placeholder,
+  .hs-form textarea::placeholder {
+    color: ${({ theme }) => theme.colors.grey_lighter} !important;
+  }
+
+  .hs-form .hs-button,
+  .hs-form input[type='submit'],
+  .hs-form .hs-submit .actions input {
+    width: 100% !important;
+    background: ${({ theme }) => theme.colors.white} !important;
+    border: none !important;
+    border-radius: 24px !important;
+    padding: 16px 24px !important;
+    font-size: 14px !important;
+    font-weight: 600 !important;
+    color: ${({ theme }) => theme.colors.black} !important;
+    font-family: Inter, sans-serif !important;
+    cursor: pointer !important;
+    transition: opacity 0.2s ease !important;
+    margin-top: 8px !important;
+  }
+
+  .hs-form .hs-button:hover,
+  .hs-form input[type='submit']:hover,
+  .hs-form .hs-submit .actions input:hover {
+    opacity: 0.85 !important;
+  }
+
+  .hs-form .hs-error-msgs,
+  .hs-form .hs-error-msg {
+    color: ${({ theme }) => theme.colors.pink} !important;
+    font-size: 12px !important;
+    margin-top: 4px !important;
+  }
+
+  .hs-form .hs-richtext,
+  .hs-form .hs-richtext * {
+    color: ${({ theme }) => theme.colors.grey_lighter} !important;
+    font-size: 12px !important;
+  }
+
+  .hs-form .legal-consent-container {
+    margin-top: 16px;
+  }
+
+  .hs-form .legal-consent-container .hs-form-booleancheckbox-display {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .hs-form .legal-consent-container .hs-form-booleancheckbox-display input {
+    width: auto !important;
+    margin-top: 3px;
+  }
+
+  .hs-form .legal-consent-container .hs-form-booleancheckbox-display span,
+  .hs-form .legal-consent-container .hs-form-booleancheckbox-display p {
+    color: ${({ theme }) => theme.colors.grey_lighter} !important;
+    font-size: 12px !important;
+    line-height: 150% !important;
+  }
+
+  .hs-form .submitted-message {
+    color: ${({ theme }) => theme.colors.white} !important;
+    font-size: 16px !important;
+    text-align: center !important;
+    padding: 24px !important;
+  }
+`;
+
+interface EventHubspotFormProps {
+  portalId: string;
+  formId: string;
+  region?: string;
+}
+
+export const EventHubspotForm = ({ portalId, formId, region = 'na1' }: EventHubspotFormProps) => {
+  const { isMobile } = useMobile();
+
+  return (
+    <Card $isMobile={isMobile}>
+      <Script src={`https://js.hsforms.net/forms/embed/developer/${portalId}.js`} strategy='afterInteractive' />
+
+      <Text fontSize={isMobile ? 28 : 38} fontWeight={600} lineHeight='110%'>
+        Schedule a meeting with us at the event!
+      </Text>
+
+      <div className='hs-form-html' data-region={region} data-form-id={formId} data-portal-id={portalId} />
+    </Card>
+  );
+};

--- a/src/containers/event-single/index.tsx
+++ b/src/containers/event-single/index.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { useMobile } from '@/contexts';
 import { EventMap } from './event-map';
 import { EventForm } from './event-form';
+import { EventHubspotForm } from './event-hubspot-form';
 import { EventTable } from './event-table';
 import { EventHeader } from './event-header';
 import type { EventPost } from '@/types';
@@ -45,7 +46,11 @@ export const EventSingle = ({ event }: EventSingleProps) => {
           </FlexColumn>
 
           <FlexColumn $gap={isMobile ? 32 : 48}>
-            <EventForm eventName={event.title} />
+            {event.hubspotFormId && event.hubspotPortalId ? (
+              <EventHubspotForm portalId={event.hubspotPortalId} formId={event.hubspotFormId} />
+            ) : (
+              <EventForm eventName={event.title} />
+            )}
             <EventMap location={event.location} />
           </FlexColumn>
         </WrapContent>

--- a/src/libs/sanity.ts
+++ b/src/libs/sanity.ts
@@ -55,7 +55,9 @@ const EVENT_FIELDS = `
   location,
   booth,
   content,
-  customHtml
+  customHtml,
+  hubspotFormId,
+  hubspotPortalId
 `;
 
 export const getAllEvents = async (): Promise<EventPost[]> => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,8 @@ export interface EventPost {
   booth?: string;
   content?: string;
   customHtml?: string;
+  hubspotFormId?: string;
+  hubspotPortalId?: string;
 }
 
 export interface WebinarSpeaker {


### PR DESCRIPTION
## Summary
- Adds two optional Sanity fields on the Event schema: **HubSpot Form ID** and **HubSpot Portal ID**.
- When both are set on an event, the page renders an embedded HubSpot form (styled to match the dark event card). Otherwise, the existing custom contact form continues to render.
- No visual or behavioral change to any existing event until the IDs are filled in via Sanity Studio.

## Why
The CNCF Observability Summit 2026 event page (and future events) needs leads to flow into HubSpot with proper campaign attribution instead of through the custom contact endpoint. Making this opt-in per event keeps every other event untouched and lets us pick which events use HubSpot.

## How to activate (post-merge)
1. After deploy, open the event in Sanity Studio (odigos.io/studio)
2. Fill in **HubSpot Form ID** and **HubSpot Portal ID**
3. Publish — page swaps to the HubSpot embed on next revalidation

## Files
- `sanity/schemas/event.ts` — two new optional schema fields
- `src/types/index.ts` — `EventPost` type updated
- `src/libs/sanity.ts` — fields added to `EVENT_FIELDS` query
- `src/containers/event-single/event-hubspot-form/` — new component, dark-themed, uses the same `js.hsforms.net/forms/embed/developer/{portalId}.js` loader pattern already used by the dinner-event flow
- `src/containers/event-single/index.tsx` — conditional render

## Test plan
- [ ] Existing events render unchanged (no IDs set)
- [ ] After deploy, set HubSpot IDs on a test event in Sanity Studio and confirm the embedded form replaces the default form
- [ ] Submit through the HubSpot form and confirm the lead lands in HubSpot with the right campaign attribution