### PR TITLE
fix(events): revert HubSpot embed to inline developer renderer

### DIFF
--- a/src/containers/event-single/event-hubspot-form/index.tsx
+++ b/src/containers/event-single/event-hubspot-form/index.tsx
@@ -190,13 +190,13 @@ export const EventHubspotForm = ({ portalId, formId, region = 'na1' }: EventHubs
 
   return (
     <Card $isMobile={isMobile}>
-      <Script src={`https://js.hsforms.net/forms/embed/${portalId}.js`} strategy='afterInteractive' />
+      <Script src={`https://js.hsforms.net/forms/embed/developer/${portalId}.js`} strategy='afterInteractive' />
 
       <Text fontSize={isMobile ? 28 : 38} fontWeight={600} lineHeight='110%'>
         Schedule a meeting with us at the event!
       </Text>
 
-      <div className='hs-form-frame' data-region={region} data-form-id={formId} data-portal-id={portalId} />
+      <div className='hs-form-html' data-region={region} data-form-id={formId} data-portal-id={portalId} />
     </Card>
   );
 };


### PR DESCRIPTION
## Summary
- PR #311 inadvertently switched the embed container from \`hs-form-html\` to \`hs-form-frame\` and the script URL to \`/embed/{portalId}.js\`. That combo is the iframe-only renderer (form lives in a cross-origin iframe at \`js.hsforms.net\`), so the styled-components overrides cannot reach the form elements — prod shows HubSpot default light styling.
- Reverts to \`hs-form-html\` + \`/embed/developer/{portalId}.js\`. This is the inline developer renderer, which injects the \`hsfc-*\` class tree into the parent DOM where the dark-theme overrides from PR #311 apply.

## Test plan
- [ ] After deploy, https://odigos.io/events/cncf-observability-summit-2026 form matches the dark inputs / white labels look from PlatformCon
- [ ] Form still submits and lead lands in HubSpot

## Why local can't verify
HubSpot's embed only inline-injects the form into the parent DOM on whitelisted domains (e.g. odigos.io). On localhost it renders inside a cross-origin iframe regardless of which embed snippet is used. Visual verification has to happen on prod.