### PR TITLE
style(events): match event form to happy-hour landing page styling

### DIFF
--- a/src/containers/event-single/event-hubspot-form/index.tsx
+++ b/src/containers/event-single/event-hubspot-form/index.tsx
@@ -81,7 +81,7 @@ const Card = styled.div<{ $isMobile: boolean }>`
   .hsfc-EmailInput,
   .hsfc-PhoneInput,
   .hsfc-NumberInput,
-  .hsfc-TextAreaInput,
+  .hsfc-TextareaInput,
   .hsfc-DropdownInput,
   input.hsfc-Input,
   textarea.hsfc-Input,
@@ -105,7 +105,7 @@ const Card = styled.div<{ $isMobile: boolean }>`
   .hsfc-EmailInput:focus,
   .hsfc-PhoneInput:focus,
   .hsfc-NumberInput:focus,
-  .hsfc-TextAreaInput:focus,
+  .hsfc-TextareaInput:focus,
   .hsfc-DropdownInput:focus,
   input.hsfc-Input:focus,
   textarea.hsfc-Input:focus,
@@ -116,7 +116,7 @@ const Card = styled.div<{ $isMobile: boolean }>`
   .hsfc-TextInput::placeholder,
   .hsfc-EmailInput::placeholder,
   .hsfc-PhoneInput::placeholder,
-  .hsfc-TextAreaInput::placeholder,
+  .hsfc-TextareaInput::placeholder,
   input.hsfc-Input::placeholder,
   textarea.hsfc-Input::placeholder {
     color: ${({ theme }) => theme.colors.grey} !important;

--- a/src/containers/event-single/event-hubspot-form/index.tsx
+++ b/src/containers/event-single/event-hubspot-form/index.tsx
@@ -4,26 +4,32 @@ import React from 'react';
 import Script from 'next/script';
 import { useMobile } from '@/contexts';
 import styled from 'styled-components';
-import { Text } from '@/components';
 
 const Card = styled.div<{ $isMobile: boolean }>`
-  background: ${({ theme }) => theme.colors.grey_cold};
-  border-radius: 32px;
+  background: ${({ theme }) => theme.colors.black_light};
   border: 1px solid ${({ theme }) => theme.colors.grey_darker};
-  padding: ${({ $isMobile }) => ($isMobile ? 32 : 64)}px;
+  border-radius: 32px;
+  padding: ${({ $isMobile }) => ($isMobile ? '32px 24px' : '40px 32px')};
   display: flex;
   flex-direction: column;
-  gap: 32px;
+  gap: 16px;
+  transition: border-color 0.3s ease;
 
-  /* HubSpot new form renderer (hsfc-*) — strip its chrome and re-style for the dark card */
+  &:hover {
+    border-color: #5e5e5e;
+  }
+
+  /* Strip HubSpot's internal chrome so the card owns the spacing */
   --hsf-background__padding: 0px;
+  --hsf-default-background__padding: 0px;
   --hsf-background-color: transparent;
 
   .hsfc-Renderer,
   .hsfc-FormWrapper,
   .hsfc-Form,
   .hsfc-Step,
-  .hsfc-Step__Content {
+  .hsfc-Step__Content,
+  [data-hsfc-id] {
     background: transparent !important;
     padding: 0 !important;
     width: 100% !important;
@@ -35,27 +41,32 @@ const Card = styled.div<{ $isMobile: boolean }>`
   .hsfc-Form {
     display: flex !important;
     flex-direction: column !important;
-    gap: 20px !important;
+    gap: 16px !important;
   }
 
   .hsfc-Row {
     display: flex !important;
     flex-direction: ${({ $isMobile }) => ($isMobile ? 'column' : 'row')} !important;
-    gap: 16px !important;
+    gap: 12px !important;
     width: 100% !important;
+    margin: 0 !important;
   }
 
   .hsfc-Row > * {
     flex: 1 !important;
     min-width: 0 !important;
+    width: 100% !important;
   }
 
+  /* Labels — off-white, small, tight */
   .hsfc-FieldLabel,
   .hsfc-FieldLabel * {
-    color: ${({ theme }) => theme.colors.white} !important;
-    font-size: 14px !important;
+    color: ${({ theme }) => theme.colors.off_white} !important;
+    font-size: 13px !important;
     font-weight: 500 !important;
-    margin-bottom: 8px !important;
+    line-height: 1.3 !important;
+    margin-bottom: 4px !important;
+    display: block !important;
     text-align: left !important;
     font-family: Inter, sans-serif !important;
   }
@@ -65,6 +76,7 @@ const Card = styled.div<{ $isMobile: boolean }>`
     color: ${({ theme }) => theme.colors.pink} !important;
   }
 
+  /* Inputs — black_lighter bg, white text, slim padding */
   .hsfc-TextInput,
   .hsfc-EmailInput,
   .hsfc-PhoneInput,
@@ -75,16 +87,18 @@ const Card = styled.div<{ $isMobile: boolean }>`
   textarea.hsfc-Input,
   select.hsfc-Input {
     width: 100% !important;
-    background: ${({ theme }) => theme.colors.black} !important;
+    background: ${({ theme }) => theme.colors.black_lighter} !important;
     border: 1px solid ${({ theme }) => theme.colors.grey_darker} !important;
     border-radius: 8px !important;
-    padding: 14px 16px !important;
+    padding: 10px 12px !important;
     font-size: 14px !important;
     color: ${({ theme }) => theme.colors.white} !important;
     font-family: Inter, sans-serif !important;
     box-sizing: border-box !important;
-    transition: border-color 0.2s ease !important;
+    transition: border-color 0.3s ease !important;
     box-shadow: none !important;
+    outline: none !important;
+    margin-top: 0 !important;
   }
 
   .hsfc-TextInput:focus,
@@ -96,7 +110,6 @@ const Card = styled.div<{ $isMobile: boolean }>`
   input.hsfc-Input:focus,
   textarea.hsfc-Input:focus,
   select.hsfc-Input:focus {
-    outline: none !important;
     border-color: ${({ theme }) => theme.colors.purple} !important;
   }
 
@@ -106,44 +119,61 @@ const Card = styled.div<{ $isMobile: boolean }>`
   .hsfc-TextAreaInput::placeholder,
   input.hsfc-Input::placeholder,
   textarea.hsfc-Input::placeholder {
-    color: ${({ theme }) => theme.colors.grey_lighter} !important;
+    color: ${({ theme }) => theme.colors.grey} !important;
+    font-size: 13px !important;
     opacity: 1 !important;
   }
 
-  /* Submit button */
+  /* Chrome autofill — keep the dark bg */
+  .hsfc-TextInput:-webkit-autofill,
+  .hsfc-EmailInput:-webkit-autofill,
+  input.hsfc-Input:-webkit-autofill {
+    -webkit-box-shadow: 0 0 0 1000px ${({ theme }) => theme.colors.black_lighter} inset !important;
+    -webkit-text-fill-color: ${({ theme }) => theme.colors.white} !important;
+    border: 1px solid ${({ theme }) => theme.colors.grey_darker} !important;
+    transition: background-color 5000s ease-in-out 0s !important;
+  }
+
+  /* Submit button — cyan pill, dark text, purple hover */
   .hsfc-Button,
   .hsfc-PrimaryButton,
   button.hsfc-Button,
   button[type='submit'] {
     width: 100% !important;
-    background: ${({ theme }) => theme.colors.white} !important;
-    border: none !important;
-    border-radius: 24px !important;
-    padding: 16px 24px !important;
-    font-size: 14px !important;
-    font-weight: 600 !important;
+    background: ${({ theme }) => theme.colors.cyan} !important;
     color: ${({ theme }) => theme.colors.black} !important;
+    border: none !important;
+    border-radius: 8px !important;
+    padding: 12px 24px !important;
+    font-size: 15px !important;
+    font-weight: 600 !important;
     font-family: Inter, sans-serif !important;
     cursor: pointer !important;
-    transition: opacity 0.2s ease !important;
-    margin-top: 8px !important;
+    transition: background 0.3s ease, color 0.3s ease, transform 0.15s ease !important;
+    margin-top: 6px !important;
   }
 
   .hsfc-Button:hover,
   .hsfc-PrimaryButton:hover,
   button.hsfc-Button:hover,
   button[type='submit']:hover {
-    opacity: 0.85 !important;
+    background: ${({ theme }) => theme.colors.purple} !important;
+    color: ${({ theme }) => theme.colors.white} !important;
+    transform: translateY(-1px) !important;
   }
 
   /* Validation / error messaging */
   .hsfc-FieldError,
   .hsfc-FieldError *,
   .hsfc-Field__Error,
+  .hsfc-ErrorAlert,
   [class*='Error'] {
     color: ${({ theme }) => theme.colors.pink} !important;
     font-size: 12px !important;
-    margin-top: 4px !important;
+    font-weight: 400 !important;
+    line-height: 1.4 !important;
+    margin-top: 6px !important;
+    opacity: 0.85 !important;
   }
 
   /* Rich text / legal copy */
@@ -151,21 +181,26 @@ const Card = styled.div<{ $isMobile: boolean }>`
   .hsfc-RichText *,
   .hsfc-LegalConsent,
   .hsfc-LegalConsent * {
-    color: ${({ theme }) => theme.colors.grey_lighter} !important;
+    color: ${({ theme }) => theme.colors.grey} !important;
     font-size: 12px !important;
-    line-height: 150% !important;
+    line-height: 1.5 !important;
   }
 
   .hsfc-LegalConsent a {
-    color: ${({ theme }) => theme.colors.cyan} !important;
+    color: ${({ theme }) => theme.colors.grey} !important;
     text-decoration: underline !important;
+    transition: color 0.3s ease !important;
+  }
+
+  .hsfc-LegalConsent a:hover {
+    color: ${({ theme }) => theme.colors.cyan} !important;
   }
 
   /* Checkboxes */
   .hsfc-CheckboxField,
   .hsfc-CheckboxField label,
   .hsfc-CheckboxField span {
-    color: ${({ theme }) => theme.colors.grey_lighter} !important;
+    color: ${({ theme }) => theme.colors.grey } !important;
     font-size: 12px !important;
   }
 
@@ -177,6 +212,23 @@ const Card = styled.div<{ $isMobile: boolean }>`
     text-align: center !important;
     padding: 24px 0 !important;
   }
+`;
+
+const Heading = styled.h2`
+  font-size: 22px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.white};
+  line-height: 120%;
+  margin: 0 0 8px 0;
+  font-family: Inter, sans-serif;
+`;
+
+const Subtext = styled.p`
+  font-size: 13px;
+  color: ${({ theme }) => theme.colors.grey};
+  line-height: 18px;
+  margin: 0 0 16px 0;
+  font-family: Inter, sans-serif;
 `;
 
 interface EventHubspotFormProps {
@@ -192,9 +244,8 @@ export const EventHubspotForm = ({ portalId, formId, region = 'na1' }: EventHubs
     <Card $isMobile={isMobile}>
       <Script src={`https://js.hsforms.net/forms/embed/developer/${portalId}.js`} strategy='afterInteractive' />
 
-      <Text fontSize={isMobile ? 28 : 38} fontWeight={600} lineHeight='110%'>
-        Schedule a meeting with us at the event!
-      </Text>
+      <Heading>Schedule a meeting with us at the event</Heading>
+      <Subtext>Stop by our booth or grab time with the team during the conference.</Subtext>
 
       <div className='hs-form-html' data-region={region} data-form-id={formId} data-portal-id={portalId} />
     </Card>


### PR DESCRIPTION
## Summary
- Re-skins \`EventHubspotForm\` to match the form-card on the CNCF happy-hour landing page so all Odigos forms look like one system.
- Card: \`black_light\` bg, \`grey_darker\` border, hover lifts to \`#5e5e5e\`.
- Labels: \`off_white\`, 13px, slim margin.
- Inputs: \`black_lighter\` bg, 8px radius, 10/12px padding, purple focus border, grey placeholder; Chrome autofill kept on dark bg.
- Submit: cyan pill, dark text, flips to purple on hover with a 1px lift.
- Heading: 22px h2, with a small grey subtext below.

Reference: \`marketing/templates/landing-page-templates/cncf-happyhour-landing-page.html\` in the marketing repo.

## Test plan
- [ ] After deploy, https://odigos.io/events/cncf-observability-summit-2026 form visually matches the happy-hour form
- [ ] Submit still works and lands the lead in HubSpot

## Why local can't verify
HubSpot inline-renders only on whitelisted domains (e.g. odigos.io); on localhost it falls back to a cross-origin iframe where the styled-components CSS can't reach.