### PR TITLE
fix(contact): stop blank/bot contact-form submissions

### DIFF
--- a/src/components/honeypot/index.tsx
+++ b/src/components/honeypot/index.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React from 'react';
+
+interface HoneypotProps {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+// Anti-spam honeypot. The field is hidden from real users (off-screen + aria-hidden
+// + not tabbable), so a human never fills it in. Spam bots that blindly populate
+// every field will fill it, which lets us silently drop their (usually blank)
+// submissions before they ever reach the contact API.
+const wrapperStyle: React.CSSProperties = {
+  position: 'absolute',
+  left: '-9999px',
+  top: 0,
+  width: 1,
+  height: 1,
+  overflow: 'hidden',
+};
+
+export const Honeypot = ({ value, onChange }: HoneypotProps) => (
+  <div aria-hidden='true' style={wrapperStyle}>
+    <label>
+      Company website
+      <input type='text' name='companyWebsite' tabIndex={-1} autoComplete='off' value={value} onChange={onChange} />
+    </label>
+  </div>
+);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 export * from './banner-image';
 export * from './button';
 export * from './card';
+export * from './honeypot';
 export * from './html-embed';
 export * from './input';
 export * from './mardown-preview';

--- a/src/containers/event-single/event-form/index.tsx
+++ b/src/containers/event-single/event-form/index.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { useMobile } from '@/contexts';
 import { useContactForm } from '@/hooks';
 import { FlexColumn, FlexRow } from '@/styles';
-import { Button, Input, Text } from '@/components';
+import { Button, Honeypot, Input, Text } from '@/components';
 import styled, { useTheme } from 'styled-components';
 import { isFreeEmail, validateEmail } from '@/functions';
 
@@ -21,7 +21,7 @@ const Form = styled.form<{ $isMobile: boolean }>`
 export const EventForm = ({ eventName }: { eventName: string }) => {
   const theme = useTheme();
   const { isMobile } = useMobile();
-  const { formData, handleFormDataChange, formErrors, handleFormErrorChange, resetFormErrors, submitToContactService } = useContactForm();
+  const { formData, handleFormDataChange, honeypot, handleHoneypotChange, formErrors, handleFormErrorChange, resetFormErrors, submitToContactService } = useContactForm();
 
   const [isLoading, setIsLoading] = useState(false);
   const [apiError, setApiError] = useState('');
@@ -80,6 +80,7 @@ export const EventForm = ({ eventName }: { eventName: string }) => {
 
   return (
     <Form $isMobile={isMobile} onSubmit={onSubmit}>
+      <Honeypot value={honeypot} onChange={handleHoneypotChange} />
       <Text fontSize={isMobile ? 28 : 38} fontWeight={600} lineHeight='110%'>
         {isDone ? 'Thanks for scheduling a meeting with us!' : 'Schedule a meeting with us at the event!'}
       </Text>

--- a/src/containers/modals/contact-us-modal/index.tsx
+++ b/src/containers/modals/contact-us-modal/index.tsx
@@ -6,7 +6,7 @@ import { useContactForm } from '@/hooks';
 import { FlexColumn, hexOpacity } from '@/styles';
 import styled, { useTheme } from 'styled-components';
 import { isFreeEmail, validateEmail } from '@/functions';
-import { Button, Input, Modal, Text, TextArea } from '@/components';
+import { Button, Honeypot, Input, Modal, Text, TextArea } from '@/components';
 
 interface ContactUsModalProps {
   isOpen: boolean;
@@ -37,7 +37,7 @@ const PushRight = styled.div<{ $isMobile: boolean }>`
 export const ContactUsModal = ({ isOpen, onClose }: ContactUsModalProps) => {
   const theme = useTheme();
   const { isMobile } = useMobile();
-  const { formData, handleFormDataChange, resetFormData, formErrors, handleFormErrorChange, resetFormErrors, submitToContactService } = useContactForm();
+  const { formData, handleFormDataChange, resetFormData, honeypot, handleHoneypotChange, formErrors, handleFormErrorChange, resetFormErrors, submitToContactService } = useContactForm();
 
   const [isLoading, setIsLoading] = useState(false);
   const [apiError, setApiError] = useState('');
@@ -101,6 +101,7 @@ export const ContactUsModal = ({ isOpen, onClose }: ContactUsModalProps) => {
       </Text>
 
       <Form $isMobile={isMobile} onSubmit={onSubmit}>
+        <Honeypot value={honeypot} onChange={handleHoneypotChange} />
         <HalfForm $isMobile={isMobile}>
           <Input name='firstName' label='First Name' required value={formData.firstName} onChange={onChange} disabled={isLoading} errorMessage={formErrors.firstName} stretch />
           <Input name='lastName' label='Last Name' required value={formData.lastName} onChange={onChange} disabled={isLoading} errorMessage={formErrors.lastName} stretch />

--- a/src/containers/modals/trial-modal/index.tsx
+++ b/src/containers/modals/trial-modal/index.tsx
@@ -6,7 +6,7 @@ import { useContactForm } from '@/hooks';
 import styled, { useTheme } from 'styled-components';
 import { isFreeEmail, validateEmail } from '@/functions';
 import { FlexColumn, FlexRow, hexOpacity } from '@/styles';
-import { Button, Input, Modal, Text } from '@/components';
+import { Button, Honeypot, Input, Modal, Text } from '@/components';
 
 interface TrialModalProps {
   isOpen: boolean;
@@ -85,7 +85,7 @@ const SuccessMark = styled.div`
 export const TrialModal = ({ isOpen, onClose }: TrialModalProps) => {
   const theme = useTheme();
   const { isMobile } = useMobile();
-  const { formData, handleFormDataChange, resetFormData, formErrors, handleFormErrorChange, resetFormErrors, submitToContactService } = useContactForm();
+  const { formData, handleFormDataChange, resetFormData, honeypot, handleHoneypotChange, formErrors, handleFormErrorChange, resetFormErrors, submitToContactService } = useContactForm();
 
   const [isLoading, setIsLoading] = useState(false);
   const [apiError, setApiError] = useState('');
@@ -167,6 +167,7 @@ export const TrialModal = ({ isOpen, onClose }: TrialModalProps) => {
 
           <Col $isMobile={isMobile}>
             <Form onSubmit={onSubmit}>
+              <Honeypot value={honeypot} onChange={handleHoneypotChange} />
               <Input name='firstName' label='Name' required autoFocus value={formData.firstName} onChange={onChange} disabled={isLoading} errorMessage={formErrors.firstName} stretch />
               <Input name='email' label='Work Email' required value={formData.email} onChange={onChange} disabled={isLoading} errorMessage={formErrors.email} stretch />
               <Input name='company' label='Company' value={formData.company} onChange={onChange} disabled={isLoading} stretch />

--- a/src/hooks/useContactForm.ts
+++ b/src/hooks/useContactForm.ts
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { usePlausible } from './usePlausible';
+import { isFreeEmail, validateEmail } from '@/functions';
 import { CONTACT_API_URL, SLACK_CONTACT_API_URL } from '@/constants';
 
 enum ContactFormEvent {
@@ -58,6 +59,13 @@ export const useContactForm = () => {
     setFormData({ ...INITIAL_FORM_DATA });
   };
 
+  // Hidden anti-spam field. Real users never see or fill it; bots that auto-fill
+  // every field will, so a non-empty value flags the submission as spam.
+  const [honeypot, setHoneypot] = useState('');
+  const handleHoneypotChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setHoneypot(e.target.value);
+  };
+
   const [formErrors, setFormErrors] = useState<Partial<Record<keyof ContactForm, string>>>({});
   const handleFormErrorChange = (key?: keyof ContactForm, error?: string, fullObject?: typeof formErrors) => {
     setFormErrors(
@@ -72,13 +80,34 @@ export const useContactForm = () => {
   };
 
   const submitToContactService = async (eventName?: string): Promise<string> => {
+    // Honeypot tripped => almost certainly a bot. Drop it silently and report
+    // success so the bot doesn't retry, but never hit the contact APIs.
+    if (honeypot.trim()) return '';
+
+    // Centralized guard: this hook is the single source of truth for what may be
+    // sent to the contact APIs. Even if a caller (or a bot driving the page)
+    // skips its own validation, we never forward a blank/invalid submission that
+    // would produce an empty notification.
+    const firstName = formData.firstName.trim();
+    const lastName = formData.lastName.trim();
+    const email = formData.email.trim();
+    const phoneNumber = formData.phoneNumber.trim();
+    const company = formData.company.trim();
+    const message = (eventName || formData.message).trim();
+
+    if (!firstName || !email || !validateEmail(email) || isFreeEmail(email)) {
+      return 'Please enter your name and a valid business email address.';
+    }
+
+    const fullName = `${firstName} ${lastName}`.trim();
+
     trackEvent(ContactFormEvent.ContactFormSubmitted, {
       props: {
-        name: `${formData.firstName} ${formData.lastName}`,
-        email: formData.email,
-        phone: formData.phoneNumber,
-        organization: formData.company,
-        message: eventName || formData.message,
+        name: fullName,
+        email,
+        phone: phoneNumber,
+        organization: company,
+        message,
       },
     });
 
@@ -89,20 +118,20 @@ export const useContactForm = () => {
     });
 
     const contactError = await sendToService(CONTACT_API_URL, {
-      fullName: `${formData.firstName} ${formData.lastName}`,
-      businessEmail: formData.email,
-      phoneNumber: formData.phoneNumber,
-      organizationName: formData.company,
-      message: eventName || formData.message,
+      fullName,
+      businessEmail: email,
+      phoneNumber,
+      organizationName: company,
+      message,
     });
     if (contactError) return contactError;
 
     const slackError = await sendToService(SLACK_CONTACT_API_URL, {
-      name: `${formData.firstName} ${formData.lastName}`,
-      email: formData.email,
-      phone: formData.phoneNumber,
-      organization: formData.company,
-      message: eventName || formData.message,
+      name: fullName,
+      email,
+      phone: phoneNumber,
+      organization: company,
+      message,
     });
     if (slackError) return slackError;
 
@@ -113,6 +142,8 @@ export const useContactForm = () => {
     formData,
     handleFormDataChange,
     resetFormData,
+    honeypot,
+    handleHoneypotChange,
     formErrors,
     handleFormErrorChange,
     resetFormErrors,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The contact form (and the trial/event forms) talk to the `putContactFormItem` Lambda + a Slack-notification endpoint. The team was getting **lots of blank-form notifications**.

## Root cause

The endpoints are hard-coded in the client bundle and the forms had **no anti-bot protection**. Real users can't send a blank form (each form validates name + business email), so the blank notifications were coming from spam bots that discover the public endpoint / auto-submit the page. On top of that, `useContactForm.submitToContactService` had **no guard of its own** — validation lived only in each component, so the hook would forward whatever was in state straight to both APIs (and Plausible/dataLayer).

## Fix

- **Honeypot field** added to the contact, trial, and event forms. It's hidden from humans (off-screen, `aria-hidden`, `tabIndex={-1}`, `autoComplete="off"`); bots that blindly fill every field trip it and the submission is silently dropped (we return success so the bot doesn't retry).
- **Centralized guard in `useContactForm`** — the hook is now the single source of truth. It refuses to fire analytics/dataLayer events or call the contact + Slack APIs unless a name and a valid business email are present, and it trims all values so whitespace-only fields can't produce empty notifications. This protects every current and future caller, not just the components that happen to validate today.

## Notes / limitations

- The Lambda itself is not in this repo, so this is a client-side mitigation. It stops bots that drive the page and guarantees the client never emits a blank/whitespace submission. For defense-in-depth against bots that POST directly to the endpoint, the Lambda should also validate required fields server-side (reject empty `fullName`/`businessEmail`) — recommended as a follow-up.

## Verification

- `yarn lint` passes (`--max-warnings 0`)
- `tsc --noEmit` passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc89860c-e92f-4943-82c3-783ae117f94e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc89860c-e92f-4943-82c3-783ae117f94e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

